### PR TITLE
Add Python 3.7 And Django2.1 To Tox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.11
-psycopg2==2.6.1
+psycopg2==2.7.2
 dj-database-url==0.4.1
 gunicorn==19.6.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = {py35,py36}-1.11.X,{py35,py36}-2.0.X
+envlist = {py35,py3,py37}-1.11.X,{py35,py3,py37}-2.0.X,{py35,py3,py37}-2.1.X
 
 [testenv]
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     -rrequirements.txt
 commands = {envpython} runtests.py


### PR DESCRIPTION
Add python3.7 and Django 2.1 to the tox file's `envlist`, and also update psycopg2, so it works with Postgres > 10.